### PR TITLE
Update CSO to use quay-v3.5 channel

### DIFF
--- a/openshift/container-security-operator.yaml
+++ b/openshift/container-security-operator.yaml
@@ -15,7 +15,7 @@ objects:
     name: container-security-operator
     namespace: ${TARGET_NAMESPACE}
   spec:
-    channel: quay-v3.3
+    channel: quay-v3.5
     name: container-security-operator
     source: redhat-operators
     sourceNamespace: openshift-marketplace


### PR DESCRIPTION
This update is required for OpenShift 4.9 compatibility